### PR TITLE
fix(import): Reject on error by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ const productType = {
   description: '<some-description>'
 }
 const config = {
+  importerConfig: {
+    rejectOnError: true
+  },
   sphereClientConfig: {
     config: {
       project_key: <PROJECT_KEY>,
@@ -88,6 +91,9 @@ productTypeImport.importProductType(productType)
   // }
 })
 ```
+
+When there is an error during processing productTypes, process will by default save this error to `summary.errors` array and reject. If the configuration flag `importerConfig.rejectOnError` is set to `false` the importer will only push error to summary and then continue with next productType.
+ 
 ## Contributing
   See [CONTRIBUTING.md](CONTRIBUTING.md) file for info on how to contribute to this library
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ const productType = {
 }
 const config = {
   importerConfig: {
-    rejectOnError: true
+    continueOnProblems: false
   },
   sphereClientConfig: {
     config: {
@@ -92,7 +92,7 @@ productTypeImport.importProductType(productType)
 })
 ```
 
-When there is an error during processing productTypes, process will by default save this error to `summary.errors` array and reject. If the configuration flag `importerConfig.rejectOnError` is set to `false` the importer will only push error to summary and then continue with next productType.
+When there is an error during processing productTypes, process will by default save this error to `summary.errors` array and reject. If the configuration flag `importerConfig.continueOnProblems` is set to `true` the importer will only push error to summary and then continue with next productType.
  
 ## Contributing
   See [CONTRIBUTING.md](CONTRIBUTING.md) file for info on how to contribute to this library

--- a/src/product-type-import.js
+++ b/src/product-type-import.js
@@ -31,7 +31,7 @@ export default class ProductTypeImport {
 
   constructor (logger, { sphereClientConfig, importerConfig }) {
     const defaultConfig = {
-      rejectOnError: true,
+      continueOnProblems: false,
     }
 
     this.logger = logger
@@ -65,9 +65,9 @@ export default class ProductTypeImport {
       .then(() => this._importValidatedProductType(productType))
       .catch((error) => {
         this.summary.errors.push({ productType, error })
-        return this.config.rejectOnError
-          ? Promise.reject(error)
-          : Promise.resolve()
+        return this.config.continueOnProblems
+          ? Promise.resolve()
+          : Promise.reject(error)
       })
   }
 

--- a/src/product-type-import.js
+++ b/src/product-type-import.js
@@ -58,8 +58,6 @@ export default class ProductTypeImport {
       // call next for next batch
       next()
     })
-    // errors get catched in the node-cli which also calls for the next chunk
-    // if an error occurred in this chunk
   }
 
   importProductType (productType) {

--- a/tests/integration/product-type-import.spec.js
+++ b/tests/integration/product-type-import.spec.js
@@ -53,7 +53,7 @@ test(`productType import module
   t.timeoutAfter(10000)
   const productType = {
     name: 'custom-product-type',
-    description: 'Some cool description',
+    description: 1244,
     attributes: [],
   }
   before()
@@ -61,23 +61,25 @@ test(`productType import module
       productTypeImport.importProductType(productType)
     )
     .then(() => {
-      const summary = JSON.parse(productTypeImport.summaryReport())
-      const actual = summary.errors.length
-
-      t.equal(actual, 1, 'There should be an error')
+      t.end('Error - should throw validation error')
+    })
+    .catch((err) => {
       t.equal(
-        summary.errors[0].error[0].message,
-        'should have required property \'key\''
+        err.message.includes(
+          'Validation error on productType "custom-product-type"'
+        ),
+        true,
+        'Importer should throw validation error'
       )
-      return client.productTypes.where(`name="${productType.name}"`).fetch()
-    })
-    .then(({ body: { results: productTypes } }) => {
-      const _actual = productTypes.length
 
-      t.equal(_actual, 0, 'ProductTypes should not be imported')
-      t.end()
+      return client.productTypes.where(`name="${productType.name}"`).fetch()
+        .then(({ body: { results: productTypes } }) => {
+          const _actual = productTypes.length
+
+          t.equal(_actual, 0, 'ProductTypes should not be imported')
+          t.end()
+        })
     })
-    .catch(t.end)
 })
 
 test(`productType import module

--- a/tests/unit/product-type-import.spec.js
+++ b/tests/unit/product-type-import.spec.js
@@ -9,6 +9,9 @@ const PROJECT_KEY = 'sphere-node-product-type-import'
 
 
 const options = {
+  importerConfig: {
+    rejectOnError: false,
+  },
   sphereClientConfig: {
     config: {
       project_key: PROJECT_KEY,
@@ -112,7 +115,7 @@ test(`processStream function
 
 test(`processStream function should
   call importProductType for each product-type in the given chunk`, (t) => {
-  const mockImportProductType = sinon.spy(() => {})
+  const mockImportProductType = sinon.spy(() => Promise.resolve())
   const callback = () => {}
   const productTypes = Array.from(new Array(10), () => ({ name: cuid() }))
   const importer = new ProductTypeImport(logger, options)

--- a/tests/unit/product-type-import.spec.js
+++ b/tests/unit/product-type-import.spec.js
@@ -10,7 +10,7 @@ const PROJECT_KEY = 'sphere-node-product-type-import'
 
 const options = {
   importerConfig: {
-    rejectOnError: false,
+    continueOnProblems: true,
   },
   sphereClientConfig: {
     config: {


### PR DESCRIPTION
#### Summary
Hello all,
this PR changes how the productType import module reacts when there is an error.

There are two methods which are being used from outside:
 - `processStream` - takes batch of productTypes and imports them
 - `importProductType` - takes one productTypes and imports it

If there is an error (eg. validation error) we originally pushed error to summary and resolved or requested a new chunk (in case of `processStream` method).

I think it was because of a possibility to stop import not after the first error but for example after first 10 errors when streaming productTypes.

I added a flag `rejectOnError` which will by default push error to summary and reject. If it is set to `false` it will only push error to summary.

- Tests
    - [x] Unit
    - [ ] Integration
    - [ ] Acceptance
- [ ] Documentation
